### PR TITLE
Add macOS ARM64 support

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,68 @@
+name: macOS
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-13, macos-14]  # Intel and Apple Silicon
+        BUILD_TYPE: [Debug, Release]
+        include:
+          - os: macos-13
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Export GitHub Actions cache environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+    - name: Setup vcpkg
+      run: |
+        git clone https://github.com/Microsoft/vcpkg.git
+        ./vcpkg/bootstrap-vcpkg.sh
+        echo "VCPKG_ROOT=$PWD/vcpkg" >> $GITHUB_ENV
+
+    - name: Install dependencies
+      run: |
+        brew install ninja
+        $VCPKG_ROOT/vcpkg install fmt catch2
+
+    - name: Configure CMake
+      run: |
+        cmake -B build-${{matrix.BUILD_TYPE}} \
+          -G Ninja \
+          -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}} \
+          -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+          -DLEMAC_SANITIZERS=${{ matrix.BUILD_TYPE == 'Debug' && 'ON' || 'OFF' }}
+
+    - name: Build
+      run: cmake --build build-${{matrix.BUILD_TYPE}}
+
+    - name: Unit test
+      run: ctest --test-dir build-${{matrix.BUILD_TYPE}} -V
+
+    - name: Tool test "lemacsum"
+      run: test/test_tool.sh build-${{matrix.BUILD_TYPE}}/lemacsum
+
+    - name: Run benchmarks (Release only)
+      if: matrix.BUILD_TYPE == 'Release'
+      run: |
+        echo "Running benchmarks on ${{ matrix.arch }}..."
+        ./build-${{matrix.BUILD_TYPE}}/benchmark/benchmark

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,8 +41,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install ninja
-        $VCPKG_ROOT/vcpkg install fmt catch2
+        # Ninja is often pre-installed, but ensure it's available
+        brew install ninja || true
 
     - name: Configure CMake
       run: |

--- a/src/arm64_capabilities.cpp
+++ b/src/arm64_capabilities.cpp
@@ -5,6 +5,10 @@
 #include <sys/auxv.h>
 #endif
 
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
+
 namespace {
 
 bool aes_support_impl() {
@@ -13,6 +17,10 @@ bool aes_support_impl() {
   // https://community.arm.com/arm-community-blogs/b/operating-systems-blog/posts/runtime-detection-of-cpu-features-on-an-armv8-a-cpu
   const auto hwcaps = getauxval(AT_HWCAP);
   return (hwcaps & HWCAP_AES) == HWCAP_AES;
+#elif defined(__APPLE__)
+  // All Apple Silicon Macs have AES crypto extensions
+  // M1, M2, M3 all support ARMv8.5-A which includes AES
+  return true;
 #else
 #error "unsupported implementation, fix me!"
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ std::string tohex(std::span<const std::uint8_t> binary) {
   std::string ret;
   char buf[3];
   for (auto c : binary) {
-    std::sprintf(buf, "%02x", (unsigned char)c);
+    std::snprintf(buf, sizeof(buf), "%02x", (unsigned char)c);
     ret.append(buf);
   }
   return ret;
@@ -126,7 +126,11 @@ std::string checksum(lemac::LeMac& lemac, const std::string& filename) {
 
     const auto memory_map =
         mmapper(mmap(NULL, length, PROT_READ,
-                     MAP_FILE | MAP_PRIVATE | MAP_POPULATE, fd.m_fd, 0),
+                     MAP_FILE | MAP_PRIVATE
+#ifdef __linux__
+                     | MAP_POPULATE
+#endif
+                     , fd.m_fd, 0),
                 length);
     if (memory_map.m_addr == MAP_FAILED) {
 

--- a/test/test_tool.sh
+++ b/test/test_tool.sh
@@ -8,8 +8,15 @@ me=$(basename "$0")
 rootdir=$(dirname "$0")/..
 
 if [ $# -eq 1 ]; then
-  # an existing build is to be tested (must be absolute)
-  tool="$1"
+  # an existing build is to be tested (can be relative or absolute)
+  # Convert to absolute path
+  if [[ "$1" = /* ]]; then
+    # Already absolute
+    tool="$1"
+  else
+    # Relative path - make it absolute
+    tool="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+  fi
   workdir=$rootdir/build-tool-test
 else
   builddir="$rootdir/build-tool-test"


### PR DESCRIPTION
## Summary
- Adds support for building and running LeMac on macOS ARM64 (Apple Silicon)
- Fixes compilation issues on macOS

## Changes
- Add macOS support to ARM64 capabilities detection (`src/arm64_capabilities.cpp`)
  - All Apple Silicon Macs (M1/M2/M3) have AES crypto extensions
- Fix macOS compilation issues:
  - Replace deprecated `sprintf` with `snprintf` in `src/main.cpp` and `test/tests.cpp`
  - Make `MAP_POPULATE` Linux-specific (not available on macOS) in `src/main.cpp`

## Test plan
- [x] Built successfully on Apple M3 MacBook Air
- [x] All tests pass (`ctest` shows 100% pass rate)
- [x] No warnings with the fixed code

Tested with:
- macOS on Apple M3 (ARM64)
- Apple Clang 16.0.0